### PR TITLE
Update background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,7 +35,7 @@ function showOptionsPage() {
    });
 }
 
-chrome.webNavigation.onBeforeNavigate.addListener(renavigate);
+chrome.webNavigation.onCommitted.addListener(renavigate);
 
 chrome.browserAction.onClicked.addListener( function( tab ) {
 	showOptionsPage();


### PR DESCRIPTION
Currently the extension does not change the URL unless we reload the tab. This is probably due to a change in the API last year or so.
tab.url is updated after the tab has navigated,  so if we check for a match "onBeforeNavigate" the check will fail the first time. This why the url is not changed on the first try, and the user had to reload the page to apply the new url

The easy fix is to change the triggering event to "onCommitted", so we check for a match after the url has been submitted.
The downside is that the tab has to navigate twice, but I would rather have that, than having to manually reload the tab.